### PR TITLE
chore: fix tdesign style usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ float32.app 使用 promptc 标准来实践 prompt 开发的解耦。请参阅 [p
 
 ## 前端
 
-> [!CAUTION]
-> 前端需要先运行 `tdesign.sh` 否则会丢失样式。
-
 前端使用 pnpm + React + Vite + MobX + TDesign 的结构。请使用以下命令以启动开发服务器：
 
 ```bash

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>float32: 优雅地探寻未知</title>
-    <link rel="stylesheet" href="/tdesign.min.css" />
-    <script src="/tdesign.min.js"></script>
+    <!--<link rel="stylesheet" href="/tdesign.min.css" />-->
+    <!--<script src="/tdesign.min.js"></script>-->
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" type="image/png" href="/images/logo-circle.png" />
   </head>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import './index.css'
 import {App} from "./App.tsx";
 import {createBrowserRouter, RouterProvider} from "react-router-dom";
 import {About} from "./About.tsx";
+
+import 'tdesign-react/es/style/index.css'; // 少量公共样式
+import './index.css'
 
 const router = createBrowserRouter([
   {

--- a/frontend/tdesign.sh
+++ b/frontend/tdesign.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-cd public
-rm tdesign.min.css
-rm tdesign.min.js
-wget https://unpkg.com/tdesign-react/dist/tdesign.min.css
-wget https://unpkg.com/tdesign-react/dist/tdesign.min.js
-cd ..


### PR DESCRIPTION
TDesign的组件样式是跟随组件按需引入达到样式内容大小也按需引入 但是公共variables只引入一份 所以需要手动引入这部分 涉及到没有引入会丢失样式是这个原因